### PR TITLE
Improvement: add adaptive FPS and polish launch.sh CPU governor

### DIFF
--- a/launch.sh
+++ b/launch.sh
@@ -7,24 +7,23 @@ cd "$DIR"
 
 export LD_LIBRARY_PATH="$DIR:$DIR/bin:$DIR/bin/$PLATFORM:$LD_LIBRARY_PATH:/usr/bin"
 
-# Set CPU frequency for music player (power saving)
-echo ondemand > /sys/devices/system/cpu/cpu0/cpufreq/scaling_governor
-if [ "$PLATFORM" = "tg5050" ]; then
-	echo 672000 > /sys/devices/system/cpu/cpu0/cpufreq/scaling_min_freq
-	echo 1680000 > /sys/devices/system/cpu/cpu0/cpufreq/scaling_max_freq
-else
-	echo 600000 > /sys/devices/system/cpu/cpu0/cpufreq/scaling_min_freq
-	echo 1200000 > /sys/devices/system/cpu/cpu0/cpufreq/scaling_max_freq
-fi
+CPU_FREQ=/sys/devices/system/cpu/cpu0/cpufreq
+
+# Save current CPU scaling state and restore on exit (including crash)
+PREV_GOVERNOR=$(cat "$CPU_FREQ/scaling_governor")
+PREV_MIN_FREQ=$(cat "$CPU_FREQ/scaling_min_freq")
+PREV_MAX_FREQ=$(cat "$CPU_FREQ/scaling_max_freq")
+
+restore_cpu() {
+	echo "$PREV_GOVERNOR" > "$CPU_FREQ/scaling_governor"
+	echo "$PREV_MIN_FREQ" > "$CPU_FREQ/scaling_min_freq"
+	echo "$PREV_MAX_FREQ" > "$CPU_FREQ/scaling_max_freq"
+}
+trap restore_cpu EXIT
+
+echo conservative > "$CPU_FREQ/scaling_governor"
+cat "$CPU_FREQ/cpuinfo_min_freq" > "$CPU_FREQ/scaling_min_freq"
+cat "$CPU_FREQ/cpuinfo_max_freq" > "$CPU_FREQ/scaling_max_freq"
 
 # Run the platform-specific binary
 "$DIR/bin/$PLATFORM/musicplayer.elf" &> "$LOGS_PATH/music-player.txt"
-
-# Restore default CPU settings on exit
-if [ "$PLATFORM" = "tg5050" ]; then
-	echo 672000 > /sys/devices/system/cpu/cpu0/cpufreq/scaling_min_freq
-	echo 2160000 > /sys/devices/system/cpu/cpu0/cpufreq/scaling_max_freq
-else
-	echo 600000 > /sys/devices/system/cpu/cpu0/cpufreq/scaling_min_freq
-	echo 2000000 > /sys/devices/system/cpu/cpu0/cpufreq/scaling_max_freq
-fi

--- a/src/module_common.c
+++ b/src/module_common.c
@@ -17,6 +17,12 @@
 static bool autosleep_disabled = false;
 static uint32_t last_input_time = 0;
 
+// Adaptive FPS state
+static uint32_t frame_start_time = 0;
+static bool display_off = false;
+static uint32_t display_off_time = 0;
+#define ADAPTIVE_FPS_IDLE_MS 5000
+
 // Screen off hint state
 static bool screen_off_hint_active = false;
 static uint32_t screen_off_hint_start = 0;
@@ -56,10 +62,17 @@ void ModuleCommon_init(void) {
     start_was_pressed = false;
     overlay_buttons_were_active = false;
     overlay_release_time = 0;
+    display_off = false;
+    frame_start_time = 0;
 }
 
 GlobalInputResult ModuleCommon_handleGlobalInput(SDL_Surface* screen, int* show_setting, int app_state) {
     GlobalInputResult result = {false, false, false};
+
+    // Reset adaptive FPS activity timer on any button press
+    if (PAD_anyPressed()) {
+        last_input_time = SDL_GetTicks();
+    }
 
     // Poll USB HID events (earphone buttons)
     USBHIDEvent hid_event;
@@ -290,6 +303,33 @@ bool ModuleCommon_processScreenOffHintTimeout(void) {
         return true;
     }
     return false;
+}
+
+void ModuleCommon_startFrame(void) {
+    GFX_startFrame();
+    frame_start_time = SDL_GetTicks();
+}
+
+static int get_frame_budget_ms(void) {
+    uint32_t now = SDL_GetTicks();
+    if (display_off) {
+        return (now - display_off_time > ADAPTIVE_FPS_IDLE_MS) ? 67 : 33;  // 15 or 30 FPS
+    }
+    return (now - last_input_time > ADAPTIVE_FPS_IDLE_MS) ? 33 : 17;      // 30 or 60 FPS
+}
+
+void ModuleCommon_adaptiveSync(void) {
+    int budget = get_frame_budget_ms();
+    uint32_t elapsed = SDL_GetTicks() - frame_start_time;
+    if (elapsed < (uint32_t)budget)
+        SDL_Delay(budget - elapsed);
+}
+
+void ModuleCommon_setDisplayOff(bool off) {
+    display_off = off;
+    if (off) {
+        display_off_time = SDL_GetTicks();
+    }
 }
 
 void ModuleCommon_quit(void) {

--- a/src/module_common.h
+++ b/src/module_common.h
@@ -63,6 +63,15 @@ bool ModuleCommon_checkAutoScreenOffTimeout(void);
 // Check toast state: if active and not expired, sets dirty=1; if expired, clears message and sets dirty=1.
 void ModuleCommon_tickToast(char* message, uint32_t toast_time, int* dirty);
 
+// Adaptive FPS: call instead of GFX_startFrame()
+void ModuleCommon_startFrame(void);
+
+// Adaptive FPS: call instead of GFX_sync() — sleeps based on activity state
+void ModuleCommon_adaptiveSync(void);
+
+// Adaptive FPS: notify that display backlight is off/on
+void ModuleCommon_setDisplayOff(bool off);
+
 // Clean up module common resources (call at app exit)
 void ModuleCommon_quit(void);
 

--- a/src/module_downloader.c
+++ b/src/module_downloader.c
@@ -71,7 +71,7 @@ ModuleExitReason DownloaderModule_run(SDL_Surface* screen) {
     }
 
     while (1) {
-        GFX_startFrame();
+        ModuleCommon_startFrame();
         PAD_poll();
 
         // Handle global input
@@ -90,7 +90,7 @@ ModuleExitReason DownloaderModule_run(SDL_Surface* screen) {
         }
         if (global.input_consumed) {
             if (global.dirty) dirty = 1;
-            GFX_sync();
+            ModuleCommon_adaptiveSync();
             continue;
         }
 
@@ -300,7 +300,7 @@ ModuleExitReason DownloaderModule_run(SDL_Surface* screen) {
             // Toast refresh
             ModuleCommon_tickToast(toast_message, toast_time, &dirty);
         } else {
-            GFX_sync();
+            ModuleCommon_adaptiveSync();
         }
     }
 }

--- a/src/module_library.c
+++ b/src/module_library.c
@@ -51,7 +51,7 @@ ModuleExitReason LibraryModule_run(SDL_Surface* screen) {
     int show_setting = 0;
 
     while (1) {
-        GFX_startFrame();
+        ModuleCommon_startFrame();
         PAD_poll();
 
         // Handle global input
@@ -61,7 +61,7 @@ ModuleExitReason LibraryModule_run(SDL_Surface* screen) {
         }
         if (global.input_consumed) {
             if (global.dirty) dirty = 1;
-            GFX_sync();
+            ModuleCommon_adaptiveSync();
             continue;
         }
 
@@ -116,7 +116,7 @@ ModuleExitReason LibraryModule_run(SDL_Surface* screen) {
 
             ModuleCommon_tickToast(library_toast_message, library_toast_time, &dirty);
         } else {
-            GFX_sync();
+            ModuleCommon_adaptiveSync();
         }
     }
 }

--- a/src/module_menu.c
+++ b/src/module_menu.c
@@ -19,7 +19,7 @@ int MenuModule_run(SDL_Surface* screen) {
     int show_setting = 0;
 
     while (1) {
-        GFX_startFrame();
+        ModuleCommon_startFrame();
         PAD_poll();
 
         // Handle background player updates (track advancement, resume saving)
@@ -45,7 +45,7 @@ int MenuModule_run(SDL_Surface* screen) {
         }
         if (global.input_consumed) {
             if (global.dirty) dirty = 1;
-            GFX_sync();
+            ModuleCommon_adaptiveSync();
             continue;
         }
 
@@ -110,7 +110,7 @@ int MenuModule_run(SDL_Surface* screen) {
         } else {
             // Software scroll needs continuous redraws
             if (menu_needs_scroll_redraw()) dirty = 1;
-            GFX_sync();
+            ModuleCommon_adaptiveSync();
         }
     }
 }

--- a/src/module_player.c
+++ b/src/module_player.c
@@ -334,11 +334,12 @@ static bool handle_playing_input(SDL_Surface *screen, PlayerInternalState *state
     if (ModuleCommon_isScreenOffHintActive()) {
         if (ModuleCommon_processScreenOffHintTimeout()) {
             screen_off = true;
+            ModuleCommon_setDisplayOff(true);
             GFX_clear(screen);
             GFX_flip(screen);
         }
         Player_update();
-        GFX_sync();
+        ModuleCommon_adaptiveSync();
         return true;
     }
 
@@ -347,6 +348,7 @@ static bool handle_playing_input(SDL_Surface *screen, PlayerInternalState *state
         // Wake screen with SELECT+A
         if (PAD_isPressed(BTN_SELECT) && PAD_isPressed(BTN_A)) {
             screen_off = false;
+            ModuleCommon_setDisplayOff(false);
             PLAT_enableBacklight(1);
             ModuleCommon_recordInputTime();
             *dirty = 1;
@@ -360,6 +362,7 @@ static bool handle_playing_input(SDL_Surface *screen, PlayerInternalState *state
             if (!handle_track_ended() && Player_getState() == PLAYER_STATE_STOPPED) {
                 Resume_clear();  // All tracks finished naturally
                 screen_off = false;
+                ModuleCommon_setDisplayOff(false);
                 PLAT_enableBacklight(1);
                 cleanup_playback(false);
                 load_directory(MUSIC_PATH);
@@ -367,7 +370,7 @@ static bool handle_playing_input(SDL_Surface *screen, PlayerInternalState *state
                 *dirty = 1;
             }
         }
-        GFX_sync();
+        ModuleCommon_adaptiveSync();
         return true;
     }
 
@@ -511,7 +514,7 @@ ModuleExitReason PlayerModule_run(SDL_Surface* screen) {
     }
 
     while (1) {
-        GFX_startFrame();
+        ModuleCommon_startFrame();
         PAD_poll();
 
         // Handle add-to-playlist dialog overlay
@@ -529,7 +532,7 @@ ModuleExitReason PlayerModule_run(SDL_Surface* screen) {
             // Still active, render dialog (covers entire screen)
             AddToPlaylist_render(screen);
             GFX_flip(screen);
-            GFX_sync();
+            ModuleCommon_adaptiveSync();
             continue;
         }
 
@@ -552,7 +555,7 @@ ModuleExitReason PlayerModule_run(SDL_Surface* screen) {
             }
             // Render delete dialog
             render_delete_dialog(screen);
-            GFX_sync();
+            ModuleCommon_adaptiveSync();
             continue;
         }
 
@@ -567,7 +570,7 @@ ModuleExitReason PlayerModule_run(SDL_Surface* screen) {
             }
             if (global.input_consumed) {
                 if (global.dirty) dirty = 1;
-                GFX_sync();
+                ModuleCommon_adaptiveSync();
                 continue;
             }
         }
@@ -620,7 +623,7 @@ ModuleExitReason PlayerModule_run(SDL_Surface* screen) {
             GFX_flip(screen);
             dirty = 0;
         } else if (!screen_off) {
-            GFX_sync();
+            ModuleCommon_adaptiveSync();
         }
     }
 }
@@ -704,7 +707,7 @@ ModuleExitReason PlayerModule_runWithPlaylist(SDL_Surface* screen,
     ModuleCommon_recordInputTime();
 
     while (1) {
-        GFX_startFrame();
+        ModuleCommon_startFrame();
         PAD_poll();
 
         // Handle add-to-playlist dialog overlay
@@ -722,7 +725,7 @@ ModuleExitReason PlayerModule_runWithPlaylist(SDL_Surface* screen,
             // Dialog covers entire screen, no need to render underlying content
             AddToPlaylist_render(screen);
             GFX_flip(screen);
-            GFX_sync();
+            ModuleCommon_adaptiveSync();
             continue;
         }
 
@@ -737,7 +740,7 @@ ModuleExitReason PlayerModule_runWithPlaylist(SDL_Surface* screen,
             }
             if (global.input_consumed) {
                 if (global.dirty) dirty = 1;
-                GFX_sync();
+                ModuleCommon_adaptiveSync();
                 continue;
             }
         }
@@ -746,11 +749,12 @@ ModuleExitReason PlayerModule_runWithPlaylist(SDL_Surface* screen,
         if (ModuleCommon_isScreenOffHintActive()) {
             if (ModuleCommon_processScreenOffHintTimeout()) {
                 screen_off = true;
+                ModuleCommon_setDisplayOff(true);
                 GFX_clear(screen);
                 GFX_flip(screen);
             }
             Player_update();
-            GFX_sync();
+            ModuleCommon_adaptiveSync();
             continue;
         }
 
@@ -758,6 +762,7 @@ ModuleExitReason PlayerModule_runWithPlaylist(SDL_Surface* screen,
         if (screen_off) {
             if (PAD_isPressed(BTN_SELECT) && PAD_isPressed(BTN_A)) {
                 screen_off = false;
+                ModuleCommon_setDisplayOff(false);
                 PLAT_enableBacklight(1);
                 ModuleCommon_recordInputTime();
                 dirty = 1;
@@ -770,6 +775,7 @@ ModuleExitReason PlayerModule_runWithPlaylist(SDL_Surface* screen,
                 if (!handle_track_ended() && Player_getState() == PLAYER_STATE_STOPPED) {
                     Resume_clear();  // All tracks finished naturally
                     screen_off = false;
+                    ModuleCommon_setDisplayOff(false);
                     PLAT_enableBacklight(1);
                     Player_stop();
                     cleanup_album_art_background();
@@ -777,7 +783,7 @@ ModuleExitReason PlayerModule_runWithPlaylist(SDL_Surface* screen,
                     return MODULE_EXIT_TO_MENU;
                 }
             }
-            GFX_sync();
+            ModuleCommon_adaptiveSync();
             continue;
         }
 
@@ -926,7 +932,7 @@ ModuleExitReason PlayerModule_runWithPlaylist(SDL_Surface* screen,
             GFX_flip(screen);
             dirty = 0;
         } else if (!screen_off) {
-            GFX_sync();
+            ModuleCommon_adaptiveSync();
         }
     }
 }
@@ -980,7 +986,7 @@ ModuleExitReason PlayerModule_runResume(SDL_Surface* screen, const ResumeState* 
         PlayerInternalState state = PLAYER_INTERNAL_PLAYING;
 
         while (1) {
-            GFX_startFrame();
+            ModuleCommon_startFrame();
             PAD_poll();
 
             // Handle add-to-playlist dialog overlay
@@ -996,7 +1002,7 @@ ModuleExitReason PlayerModule_runResume(SDL_Surface* screen, const ResumeState* 
                 }
                 AddToPlaylist_render(screen);
                 GFX_flip(screen);
-                GFX_sync();
+                ModuleCommon_adaptiveSync();
                 continue;
             }
 
@@ -1011,7 +1017,7 @@ ModuleExitReason PlayerModule_runResume(SDL_Surface* screen, const ResumeState* 
                 }
                 if (global.input_consumed) {
                     if (global.dirty) dirty = 1;
-                    GFX_sync();
+                    ModuleCommon_adaptiveSync();
                     continue;
                 }
             }
@@ -1065,7 +1071,7 @@ ModuleExitReason PlayerModule_runResume(SDL_Surface* screen, const ResumeState* 
                 GFX_flip(screen);
                 dirty = 0;
             } else if (!screen_off) {
-                GFX_sync();
+                ModuleCommon_adaptiveSync();
             }
         }
 

--- a/src/module_playlist.c
+++ b/src/module_playlist.c
@@ -72,7 +72,7 @@ ModuleExitReason PlaylistModule_run(SDL_Surface* screen) {
     int show_setting = 0;
 
     while (1) {
-        GFX_startFrame();
+        ModuleCommon_startFrame();
         PAD_poll();
 
         // Handle confirmation dialog
@@ -115,7 +115,7 @@ ModuleExitReason PlaylistModule_run(SDL_Surface* screen) {
             const char* confirm_title = (confirm_action == 0) ? "Delete Playlist?" : "Remove Track?";
             render_confirmation_dialog(screen, confirm_name, confirm_title);
             GFX_flip(screen);
-            GFX_sync();
+            ModuleCommon_adaptiveSync();
             continue;
         }
 
@@ -127,7 +127,7 @@ ModuleExitReason PlaylistModule_run(SDL_Surface* screen) {
         }
         if (global.input_consumed) {
             if (global.dirty) dirty = 1;
-            GFX_sync();
+            ModuleCommon_adaptiveSync();
             continue;
         }
 
@@ -283,7 +283,7 @@ ModuleExitReason PlaylistModule_run(SDL_Surface* screen) {
 
             ModuleCommon_tickToast(playlist_toast_message, playlist_toast_time, &dirty);
         } else {
-            GFX_sync();
+            ModuleCommon_adaptiveSync();
         }
     }
 }

--- a/src/module_podcast.c
+++ b/src/module_podcast.c
@@ -127,7 +127,7 @@ ModuleExitReason PodcastModule_run(SDL_Surface* screen) {
     }
 
     while (1) {
-        GFX_startFrame();
+        ModuleCommon_startFrame();
         PAD_poll();
 
         // Handle confirmation dialog
@@ -151,19 +151,19 @@ ModuleExitReason PodcastModule_run(SDL_Surface* screen) {
                 show_confirm = false;
                 Podcast_clearTitleScroll();
                 dirty = 1;
-                GFX_sync();
+                ModuleCommon_adaptiveSync();
                 continue;
             } else if (PAD_justPressed(BTN_B)) {
                 show_confirm = false;
                 Podcast_clearTitleScroll();
                 dirty = 1;
-                GFX_sync();
+                ModuleCommon_adaptiveSync();
                 continue;
             }
             // Render confirmation dialog (covers entire screen)
             render_confirmation_dialog(screen, confirm_podcast_name, "Unsubscribe?");
             GFX_flip(screen);
-            GFX_sync();
+            ModuleCommon_adaptiveSync();
             continue;
         }
 
@@ -189,7 +189,7 @@ ModuleExitReason PodcastModule_run(SDL_Surface* screen) {
             }
             if (global.input_consumed) {
                 if (global.dirty) dirty = 1;
-                GFX_sync();
+                ModuleCommon_adaptiveSync();
                 continue;
             }
         }
@@ -825,17 +825,19 @@ ModuleExitReason PodcastModule_run(SDL_Surface* screen) {
             if (ModuleCommon_isScreenOffHintActive()) {
                 if (ModuleCommon_processScreenOffHintTimeout()) {
                     screen_off = true;
+                    ModuleCommon_setDisplayOff(true);
                     GFX_clear(screen);
                     GFX_flip(screen);
                 }
                 Podcast_update();
-                GFX_sync();
+                ModuleCommon_adaptiveSync();
                 continue;
             }
             else if (screen_off) {
                 // Wake screen with SELECT+A
                 if (PAD_isPressed(BTN_SELECT) && PAD_isPressed(BTN_A)) {
                     screen_off = false;
+                    ModuleCommon_setDisplayOff(false);
                     PLAT_enableBacklight(1);
                     ModuleCommon_recordInputTime();
                     dirty = 1;
@@ -844,7 +846,7 @@ ModuleExitReason PodcastModule_run(SDL_Surface* screen) {
                 handle_hid_events();
                 ModuleCommon_handleHardwareVolume();
                 Podcast_update();
-                GFX_sync();
+                ModuleCommon_adaptiveSync();
                 continue;
             }
             else {
@@ -1039,7 +1041,7 @@ ModuleExitReason PodcastModule_run(SDL_Surface* screen) {
             // Toast refresh
             ModuleCommon_tickToast(podcast_toast_message, podcast_toast_time, &dirty);
         } else if (!screen_off) {
-            GFX_sync();
+            ModuleCommon_adaptiveSync();
         }
     }
 }

--- a/src/module_radio.c
+++ b/src/module_radio.c
@@ -136,7 +136,7 @@ ModuleExitReason RadioModule_run(SDL_Surface* screen) {
     }
 
     while (1) {
-        GFX_startFrame();
+        ModuleCommon_startFrame();
         PAD_poll();
 
         // Handle confirmation dialog
@@ -160,18 +160,18 @@ ModuleExitReason RadioModule_run(SDL_Surface* screen) {
                 }
                 show_confirm = false;
                 dirty = 1;
-                GFX_sync();
+                ModuleCommon_adaptiveSync();
                 continue;
             } else if (PAD_justPressed(BTN_B)) {
                 show_confirm = false;
                 dirty = 1;
-                GFX_sync();
+                ModuleCommon_adaptiveSync();
                 continue;
             }
             // Render confirmation dialog (covers entire screen)
             render_confirmation_dialog(screen, confirm_station_name, "Remove Station?");
             GFX_flip(screen);
-            GFX_sync();
+            ModuleCommon_adaptiveSync();
             continue;
         }
 
@@ -195,7 +195,7 @@ ModuleExitReason RadioModule_run(SDL_Surface* screen) {
             }
             if (global.input_consumed) {
                 if (global.dirty) dirty = 1;
-                GFX_sync();
+                ModuleCommon_adaptiveSync();
                 continue;
             }
         }
@@ -263,11 +263,12 @@ ModuleExitReason RadioModule_run(SDL_Surface* screen) {
             if (ModuleCommon_isScreenOffHintActive()) {
                 if (ModuleCommon_processScreenOffHintTimeout()) {
                     screen_off = true;
+                    ModuleCommon_setDisplayOff(true);
                     GFX_clear(screen);
                     GFX_flip(screen);
                 }
                 Radio_update();
-                GFX_sync();
+                ModuleCommon_adaptiveSync();
                 continue;
             }
 
@@ -276,6 +277,7 @@ ModuleExitReason RadioModule_run(SDL_Surface* screen) {
                 // Wake screen with SELECT+A
                 if (PAD_isPressed(BTN_SELECT) && PAD_isPressed(BTN_A)) {
                     screen_off = false;
+                    ModuleCommon_setDisplayOff(false);
                     PLAT_enableBacklight(1);
                     ModuleCommon_recordInputTime();
                     dirty = 1;
@@ -284,7 +286,7 @@ ModuleExitReason RadioModule_run(SDL_Surface* screen) {
                 handle_hid_events();
                 ModuleCommon_handleHardwareVolume();
                 Radio_update();
-                GFX_sync();
+                ModuleCommon_adaptiveSync();
                 continue;
             }
 
@@ -539,7 +541,7 @@ ModuleExitReason RadioModule_run(SDL_Surface* screen) {
                 ModuleCommon_tickToast(radio_toast_message, radio_toast_time, &dirty);
             }
         } else if (!screen_off) {
-            GFX_sync();
+            ModuleCommon_adaptiveSync();
         }
     }
 }

--- a/src/module_settings.c
+++ b/src/module_settings.c
@@ -41,7 +41,7 @@ ModuleExitReason SettingsModule_run(SDL_Surface* screen) {
     int show_setting = 0;
 
     while (1) {
-        GFX_startFrame();
+        ModuleCommon_startFrame();
         PAD_poll();
 
         // Handle global input first
@@ -52,7 +52,7 @@ ModuleExitReason SettingsModule_run(SDL_Surface* screen) {
         }
         if (global.input_consumed) {
             if (global.dirty) dirty = 1;
-            GFX_sync();
+            ModuleCommon_adaptiveSync();
             continue;
         }
 
@@ -255,7 +255,7 @@ ModuleExitReason SettingsModule_run(SDL_Surface* screen) {
             GFX_flip(screen);
             dirty = 0;
         } else {
-            GFX_sync();
+            ModuleCommon_adaptiveSync();
         }
     }
 }

--- a/src/module_system.c
+++ b/src/module_system.c
@@ -18,6 +18,7 @@ ModuleExitReason SystemModule_run(SDL_Surface* screen) {
     int show_setting = 0;
 
     while (1) {
+        ModuleCommon_startFrame();
         PAD_poll();
 
         // Handle global input first
@@ -28,7 +29,7 @@ ModuleExitReason SystemModule_run(SDL_Surface* screen) {
         }
         if (global.input_consumed) {
             if (global.dirty) dirty = 1;
-            GFX_sync();
+            ModuleCommon_adaptiveSync();
             continue;
         }
 
@@ -104,7 +105,7 @@ ModuleExitReason SystemModule_run(SDL_Surface* screen) {
             GFX_flip(screen);
             dirty = 0;
         } else {
-            GFX_sync();
+            ModuleCommon_adaptiveSync();
         }
     }
 }


### PR DESCRIPTION
## Summary

- Reduce battery consumption by dynamically adjusting frame rate based on user activity and display state. Idle screens drop to 30 FPS after 5s of inactivity; when screen is off, it drops further to 15 FPS. Active input returns to 60 FPS for responsive UI.
- Update launch.sh to save/restore CPU governor state via trap instead of hardcoding per-platform frequencies
- Switch to `conservative` governor for lower idle power draw

## Background

1. Music player spends too much time waking at 60 fps just to check on buttons. While this could be justified when the user actively navigates menu, it is waste of battery otherwise.

2. Music decoding is not a very demanding process, we can use the lowest cpu frequency. That would conserve some power, but still will be more than enough for music playback.

## Test plan

- [x] Verify UI is responsive during active navigation
- [x] Test screen-off/wake cycle in player, radio, and podcast modules
- [x] Verify CPU governor is restored after app exit
- [x] Test on tg5040
