### PR TITLE
Improvement: show screen-off hint on any button press

### DIFF
--- a/src/module_player.c
+++ b/src/module_player.c
@@ -330,31 +330,48 @@ static bool handle_browser_input(PlayerInternalState *state, int *dirty) {
 
 // Handle input in playing state. Returns true when main loop should continue (skip render).
 static bool handle_playing_input(SDL_Surface *screen, PlayerInternalState *state, int *dirty) {
-    // Handle screen off hint timeout
+    // Handle screen off hint
     if (ModuleCommon_isScreenOffHintActive()) {
-        if (ModuleCommon_processScreenOffHintTimeout()) {
-            screen_off = true;
-            GFX_clear(screen);
-            GFX_flip(screen);
-        }
-        Player_update();
-        GFX_sync();
-        return true;
-    }
-
-    // Handle screen off mode
-    if (screen_off) {
-        // Wake screen with SELECT+A
-        if (PAD_isPressed(BTN_SELECT) && PAD_isPressed(BTN_A)) {
-            screen_off = false;
-            PLAT_enableBacklight(1);
-            ModuleCommon_recordInputTime();
-            *dirty = 1;
-        }
-        // Handle USB/Bluetooth media and volume buttons even with screen off
         handle_hid_events();
         ModuleCommon_handleHardwareVolume();
         Player_update();
+
+        // SELECT+A during hint -> full wake
+        if (PAD_isPressed(BTN_SELECT) && PAD_isPressed(BTN_A)) {
+            ModuleCommon_resetScreenOffHint();
+            ModuleCommon_recordInputTime();
+            *dirty = 1;
+            return false;
+        } else {
+            // Any other button resets the hint timer
+            if (PAD_anyPressed()) {
+                ModuleCommon_startScreenOffHint();
+            }
+            if (ModuleCommon_processScreenOffHintTimeout()) {
+                screen_off = true;
+                GFX_clear(screen);
+                GFX_flip(screen);
+            }
+            GFX_sync();
+            return true;
+        }
+    }
+
+    // Handle screen off
+    if (screen_off) {
+        handle_hid_events();
+        ModuleCommon_handleHardwareVolume();
+        Player_update();
+
+        // Any button -> show hint
+        if (PAD_anyPressed()) {
+            screen_off = false;
+            PLAT_enableBacklight(1);
+            ModuleCommon_startScreenOffHint();
+            GFX_clear(screen);
+            render_screen_off_hint(screen);
+            GFX_flip(screen);
+        }
 
         if (Player_getState() == PLAYER_STATE_STOPPED) {
             if (!handle_track_ended() && Player_getState() == PLAYER_STATE_STOPPED) {

--- a/src/module_podcast.c
+++ b/src/module_podcast.c
@@ -821,29 +821,46 @@ ModuleExitReason PodcastModule_run(SDL_Surface* screen) {
         else if (state == PODCAST_INTERNAL_PLAYING) {
             ModuleCommon_setAutosleepDisabled(true);
 
-            // Handle screen off hint timeout
+            // Handle screen off hint
             if (ModuleCommon_isScreenOffHintActive()) {
-                if (ModuleCommon_processScreenOffHintTimeout()) {
-                    screen_off = true;
-                    GFX_clear(screen);
-                    GFX_flip(screen);
-                }
-                Podcast_update();
-                GFX_sync();
-                continue;
-            }
-            else if (screen_off) {
-                // Wake screen with SELECT+A
-                if (PAD_isPressed(BTN_SELECT) && PAD_isPressed(BTN_A)) {
-                    screen_off = false;
-                    PLAT_enableBacklight(1);
-                    ModuleCommon_recordInputTime();
-                    dirty = 1;
-                }
-                // Handle USB/Bluetooth media and volume buttons even with screen off
                 handle_hid_events();
                 ModuleCommon_handleHardwareVolume();
                 Podcast_update();
+
+                // SELECT+A during hint -> full wake
+                if (PAD_isPressed(BTN_SELECT) && PAD_isPressed(BTN_A)) {
+                    ModuleCommon_resetScreenOffHint();
+                    ModuleCommon_recordInputTime();
+                    dirty = 1;
+                    continue;
+                } else {
+                    // Any other button resets the hint timer
+                    if (PAD_anyPressed()) {
+                        ModuleCommon_startScreenOffHint();
+                    }
+                    if (ModuleCommon_processScreenOffHintTimeout()) {
+                        screen_off = true;
+                        GFX_clear(screen);
+                        GFX_flip(screen);
+                    }
+                    GFX_sync();
+                    continue;
+                }
+            }
+            else if (screen_off) {
+                handle_hid_events();
+                ModuleCommon_handleHardwareVolume();
+                Podcast_update();
+
+                // Any button -> show hint
+                if (PAD_anyPressed()) {
+                    screen_off = false;
+                    PLAT_enableBacklight(1);
+                    ModuleCommon_startScreenOffHint();
+                    GFX_clear(screen);
+                    render_screen_off_hint(screen);
+                    GFX_flip(screen);
+                }
                 GFX_sync();
                 continue;
             }

--- a/src/module_radio.c
+++ b/src/module_radio.c
@@ -259,31 +259,48 @@ ModuleExitReason RadioModule_run(SDL_Surface* screen) {
         else if (state == RADIO_INTERNAL_PLAYING) {
             ModuleCommon_setAutosleepDisabled(true);
 
-            // Handle screen off hint timeout
+            // Handle screen off hint
             if (ModuleCommon_isScreenOffHintActive()) {
-                if (ModuleCommon_processScreenOffHintTimeout()) {
-                    screen_off = true;
-                    GFX_clear(screen);
-                    GFX_flip(screen);
-                }
-                Radio_update();
-                GFX_sync();
-                continue;
-            }
-
-            // Handle screen off mode
-            if (screen_off) {
-                // Wake screen with SELECT+A
-                if (PAD_isPressed(BTN_SELECT) && PAD_isPressed(BTN_A)) {
-                    screen_off = false;
-                    PLAT_enableBacklight(1);
-                    ModuleCommon_recordInputTime();
-                    dirty = 1;
-                }
-                // Handle USB/Bluetooth media and volume buttons even with screen off
                 handle_hid_events();
                 ModuleCommon_handleHardwareVolume();
                 Radio_update();
+
+                // SELECT+A during hint -> full wake
+                if (PAD_isPressed(BTN_SELECT) && PAD_isPressed(BTN_A)) {
+                    ModuleCommon_resetScreenOffHint();
+                    ModuleCommon_recordInputTime();
+                    dirty = 1;
+                    continue;
+                } else {
+                    // Any other button resets the hint timer
+                    if (PAD_anyPressed()) {
+                        ModuleCommon_startScreenOffHint();
+                    }
+                    if (ModuleCommon_processScreenOffHintTimeout()) {
+                        screen_off = true;
+                        GFX_clear(screen);
+                        GFX_flip(screen);
+                    }
+                    GFX_sync();
+                    continue;
+                }
+            }
+
+            // Handle screen off
+            if (screen_off) {
+                handle_hid_events();
+                ModuleCommon_handleHardwareVolume();
+                Radio_update();
+
+                // Any button -> show hint
+                if (PAD_anyPressed()) {
+                    screen_off = false;
+                    PLAT_enableBacklight(1);
+                    ModuleCommon_startScreenOffHint();
+                    GFX_clear(screen);
+                    render_screen_off_hint(screen);
+                    GFX_flip(screen);
+                }
                 GFX_sync();
                 continue;
             }


### PR DESCRIPTION
## Background

When the screen is off during playback, the only way to interact is SELECT+A (which fully wakes the UI). All other button presses are silently ignored, so there's no way to discover the wake combo without prior knowledge.

## Change

Any button press while the screen is off now briefly shows a hint ("Press SELECT + A to wake screen") on a black background, then turns the screen off again after 4 seconds of inactivity. Additional button presses reset the timer. SELECT+A during the hint immediately wakes to the full player UI.

HID media buttons and hardware volume continue working during both screen-off and hint states.

Applied to player, radio, and podcast modules.

## Test plan

- [x] Play music, press SELECT, wait for screen off, press any button -> hint appears
- [x] Wait 4s with no input -> screen turns off again
- [x] Press buttons during hint -> timer resets, hint stays visible
- [x] Press SELECT+A during hint -> full wake to player UI
- [x] Verify media buttons (USB-C headphones) work during screen-off and hint
- [x] Verify hardware volume buttons work during screen-off and hint
- [x] Repeat for radio and podcast modules