### PR TITLE
feat: LEFT/RIGHT page navigation for all list screens

### DIFF
--- a/src/module_downloader.c
+++ b/src/module_downloader.c
@@ -10,6 +10,7 @@
 #include "module_library.h"
 #include "downloader.h"
 #include "ui_downloader.h"
+#include "ui_utils.h"
 #include "wifi.h"
 
 // Menu count
@@ -98,12 +99,23 @@ ModuleExitReason DownloaderModule_run(SDL_Surface* screen) {
         // MENU STATE
         // =========================================
         if (state == DOWNLOADER_INTERNAL_MENU) {
+            int items_per_page = calc_list_layout(screen).items_per_page;
             if (PAD_justRepeated(BTN_UP)) {
                 menu_selected = (menu_selected > 0) ? menu_selected - 1 : DOWNLOADER_MENU_COUNT - 1;
                 dirty = 1;
             }
             else if (PAD_justRepeated(BTN_DOWN)) {
                 menu_selected = (menu_selected < DOWNLOADER_MENU_COUNT - 1) ? menu_selected + 1 : 0;
+                dirty = 1;
+            }
+            else if (PAD_justPressed(BTN_LEFT)) {
+                int scroll = 0;
+                list_page_up(&menu_selected, &scroll, DOWNLOADER_MENU_COUNT, items_per_page);
+                dirty = 1;
+            }
+            else if (PAD_justPressed(BTN_RIGHT)) {
+                int scroll = 0;
+                list_page_down(&menu_selected, &scroll, DOWNLOADER_MENU_COUNT, items_per_page);
                 dirty = 1;
             }
             else if (PAD_justPressed(BTN_A)) {
@@ -180,6 +192,7 @@ ModuleExitReason DownloaderModule_run(SDL_Surface* screen) {
         // RESULTS STATE
         // =========================================
         else if (state == DOWNLOADER_INTERNAL_RESULTS) {
+            int items_per_page = calc_list_layout(screen).items_per_page;
             if (PAD_justRepeated(BTN_UP) && result_count > 0) {
                 if (results_selected < 0) {
                     results_selected = result_count - 1;
@@ -194,6 +207,14 @@ ModuleExitReason DownloaderModule_run(SDL_Surface* screen) {
                 } else {
                     results_selected = (results_selected < result_count - 1) ? results_selected + 1 : 0;
                 }
+                dirty = 1;
+            }
+            else if (PAD_justPressed(BTN_LEFT) && result_count > 0) {
+                list_page_up(&results_selected, &results_scroll, result_count, items_per_page);
+                dirty = 1;
+            }
+            else if (PAD_justPressed(BTN_RIGHT) && result_count > 0) {
+                list_page_down(&results_selected, &results_scroll, result_count, items_per_page);
                 dirty = 1;
             }
             else if (PAD_justPressed(BTN_A) && result_count > 0 && results_selected >= 0) {
@@ -234,6 +255,7 @@ ModuleExitReason DownloaderModule_run(SDL_Surface* screen) {
         // =========================================
         else if (state == DOWNLOADER_INTERNAL_QUEUE) {
             int qcount = Downloader_queueCount();
+            int items_per_page = calc_list_layout(screen).list_h / (SCALE1(PILL_SIZE) * 3 / 2);
 
             if (PAD_justRepeated(BTN_UP) && qcount > 0) {
                 queue_selected = (queue_selected > 0) ? queue_selected - 1 : qcount - 1;
@@ -241,6 +263,14 @@ ModuleExitReason DownloaderModule_run(SDL_Surface* screen) {
             }
             else if (PAD_justRepeated(BTN_DOWN) && qcount > 0) {
                 queue_selected = (queue_selected < qcount - 1) ? queue_selected + 1 : 0;
+                dirty = 1;
+            }
+            else if (PAD_justPressed(BTN_LEFT) && qcount > 0) {
+                list_page_up(&queue_selected, &queue_scroll, qcount, items_per_page);
+                dirty = 1;
+            }
+            else if (PAD_justPressed(BTN_RIGHT) && qcount > 0) {
+                list_page_down(&queue_selected, &queue_scroll, qcount, items_per_page);
                 dirty = 1;
             }
             else if (PAD_justPressed(BTN_A) && qcount > 0) {

--- a/src/module_library.c
+++ b/src/module_library.c
@@ -66,12 +66,23 @@ ModuleExitReason LibraryModule_run(SDL_Surface* screen) {
         }
 
         // Menu navigation
+        int items_per_page = calc_list_layout(screen).items_per_page;
         if (PAD_justRepeated(BTN_UP)) {
             menu_selected = (menu_selected > 0) ? menu_selected - 1 : LIBRARY_ITEM_COUNT - 1;
             dirty = 1;
         }
         else if (PAD_justRepeated(BTN_DOWN)) {
             menu_selected = (menu_selected < LIBRARY_ITEM_COUNT - 1) ? menu_selected + 1 : 0;
+            dirty = 1;
+        }
+        else if (PAD_justPressed(BTN_LEFT)) {
+            int scroll = 0;
+            list_page_up(&menu_selected, &scroll, LIBRARY_ITEM_COUNT, items_per_page);
+            dirty = 1;
+        }
+        else if (PAD_justPressed(BTN_RIGHT)) {
+            int scroll = 0;
+            list_page_down(&menu_selected, &scroll, LIBRARY_ITEM_COUNT, items_per_page);
             dirty = 1;
         }
         else if (PAD_justPressed(BTN_A)) {

--- a/src/module_menu.c
+++ b/src/module_menu.c
@@ -6,6 +6,7 @@
 #include "module_common.h"
 #include "module_menu.h"
 #include "ui_main.h"
+#include "ui_utils.h"
 #include "resume.h"
 #include "background.h"
 
@@ -50,6 +51,7 @@ int MenuModule_run(SDL_Surface* screen) {
         }
 
         // Menu navigation
+        int items_per_page = calc_list_layout(screen).items_per_page;
         if (PAD_justRepeated(BTN_UP)) {
             menu_selected = (menu_selected > 0) ? menu_selected - 1 : item_count - 1;
             GFX_clearLayers(LAYER_SCROLLTEXT);
@@ -57,6 +59,18 @@ int MenuModule_run(SDL_Surface* screen) {
         }
         else if (PAD_justRepeated(BTN_DOWN)) {
             menu_selected = (menu_selected < item_count - 1) ? menu_selected + 1 : 0;
+            GFX_clearLayers(LAYER_SCROLLTEXT);
+            dirty = 1;
+        }
+        else if (PAD_justPressed(BTN_LEFT)) {
+            int scroll = 0;
+            list_page_up(&menu_selected, &scroll, item_count, items_per_page);
+            GFX_clearLayers(LAYER_SCROLLTEXT);
+            dirty = 1;
+        }
+        else if (PAD_justPressed(BTN_RIGHT)) {
+            int scroll = 0;
+            list_page_down(&menu_selected, &scroll, item_count, items_per_page);
             GFX_clearLayers(LAYER_SCROLLTEXT);
             dirty = 1;
         }

--- a/src/module_player.c
+++ b/src/module_player.c
@@ -317,6 +317,14 @@ static bool handle_browser_input(PlayerInternalState *state, int *dirty) {
                 *dirty = 1;
             }
         }
+        else if (PAD_justPressed(BTN_LEFT)) {
+            list_page_up(&browser.selected, &browser.scroll_offset, browser.entry_count, browser.items_per_page);
+            *dirty = 1;
+        }
+        else if (PAD_justPressed(BTN_RIGHT)) {
+            list_page_down(&browser.selected, &browser.scroll_offset, browser.entry_count, browser.items_per_page);
+            *dirty = 1;
+        }
     }
 
     // Animate browser scroll

--- a/src/module_playlist.c
+++ b/src/module_playlist.c
@@ -133,6 +133,7 @@ ModuleExitReason PlaylistModule_run(SDL_Surface* screen) {
 
         if (state == PLAYLIST_INTERNAL_LIST) {
             int total_items = playlist_count;
+            int items_per_page = calc_list_layout(screen).items_per_page;
 
             if (PAD_justPressed(BTN_B)) {
                 GFX_clearLayers(LAYER_SCROLLTEXT);
@@ -144,6 +145,14 @@ ModuleExitReason PlaylistModule_run(SDL_Surface* screen) {
             }
             else if (total_items > 0 && PAD_justRepeated(BTN_DOWN)) {
                 list_selected = (list_selected < total_items - 1) ? list_selected + 1 : 0;
+                dirty = 1;
+            }
+            else if (PAD_justPressed(BTN_LEFT)) {
+                list_page_up(&list_selected, &list_scroll, playlist_count, items_per_page);
+                dirty = 1;
+            }
+            else if (PAD_justPressed(BTN_RIGHT)) {
+                list_page_down(&list_selected, &list_scroll, playlist_count, items_per_page);
                 dirty = 1;
             }
             else if (PAD_justPressed(BTN_A)) {
@@ -201,6 +210,7 @@ ModuleExitReason PlaylistModule_run(SDL_Surface* screen) {
 
         } else if (state == PLAYLIST_INTERNAL_DETAIL) {
             int total_items = detail_track_count;
+            int items_per_page = calc_list_layout(screen).items_per_page;
 
             if (PAD_justPressed(BTN_B)) {
                 GFX_clearLayers(LAYER_SCROLLTEXT);
@@ -214,6 +224,14 @@ ModuleExitReason PlaylistModule_run(SDL_Surface* screen) {
             }
             else if (total_items > 0 && PAD_justRepeated(BTN_DOWN)) {
                 detail_selected = (detail_selected < total_items - 1) ? detail_selected + 1 : 0;
+                dirty = 1;
+            }
+            else if (PAD_justPressed(BTN_LEFT)) {
+                list_page_up(&detail_selected, &detail_scroll, detail_track_count, items_per_page);
+                dirty = 1;
+            }
+            else if (PAD_justPressed(BTN_RIGHT)) {
+                list_page_down(&detail_selected, &detail_scroll, detail_track_count, items_per_page);
                 dirty = 1;
             }
             else if (PAD_justPressed(BTN_A)) {

--- a/src/module_podcast.c
+++ b/src/module_podcast.c
@@ -33,6 +33,7 @@ typedef enum {
 static int podcast_menu_selected = 0;
 static int podcast_menu_scroll = 0;
 static int podcast_manage_selected = 0;
+static int podcast_manage_scroll = 0;
 static int podcast_top_shows_selected = 0;
 static int podcast_top_shows_scroll = 0;
 static int podcast_search_selected = 0;
@@ -214,6 +215,7 @@ ModuleExitReason PodcastModule_run(SDL_Surface* screen) {
             Podcast_getDownloadQueue(&dl_queue_count);
             int has_downloads_item = (dl_queue_count > 0) ? 1 : 0;
             int total = cl_count + sub_count + has_downloads_item;
+            int items_per_page = calc_list_layout(screen).list_h / (SCALE1(PILL_SIZE) * 3 / 2);
 
             // Clamp selection if items changed (e.g. download queue emptied)
             if (podcast_menu_selected >= total && total > 0) {
@@ -235,6 +237,18 @@ ModuleExitReason PodcastModule_run(SDL_Surface* screen) {
                 podcast_menu_selected = (podcast_menu_selected < total - 1) ? podcast_menu_selected + 1 : 0;
                 Podcast_clearTitleScroll();
                 dirty = 1;
+            }
+            else if (PAD_justPressed(BTN_LEFT) && total > 0) {
+                if (list_page_up(&podcast_menu_selected, &podcast_menu_scroll, total, items_per_page)) {
+                    Podcast_clearTitleScroll();
+                    dirty = 1;
+                }
+            }
+            else if (PAD_justPressed(BTN_RIGHT) && total > 0) {
+                if (list_page_down(&podcast_menu_selected, &podcast_menu_scroll, total, items_per_page)) {
+                    Podcast_clearTitleScroll();
+                    dirty = 1;
+                }
             }
             else if (PAD_justPressed(BTN_A) && total > 0) {
                 if (has_downloads_item && podcast_menu_selected == cl_count + sub_count) {
@@ -353,6 +367,7 @@ ModuleExitReason PodcastModule_run(SDL_Surface* screen) {
         // =========================================
         else if (state == PODCAST_INTERNAL_MANAGE) {
             Podcast_update();
+            int items_per_page = calc_list_layout(screen).items_per_page;
 
             if (PAD_justRepeated(BTN_UP)) {
                 podcast_manage_selected = (podcast_manage_selected > 0) ? podcast_manage_selected - 1 : PODCAST_MANAGE_COUNT - 1;
@@ -361,6 +376,14 @@ ModuleExitReason PodcastModule_run(SDL_Surface* screen) {
             else if (PAD_justRepeated(BTN_DOWN)) {
                 podcast_manage_selected = (podcast_manage_selected < PODCAST_MANAGE_COUNT - 1) ? podcast_manage_selected + 1 : 0;
                 dirty = 1;
+            }
+            else if (PAD_justPressed(BTN_LEFT)) {
+                if (list_page_up(&podcast_manage_selected, &podcast_manage_scroll, PODCAST_MANAGE_COUNT, items_per_page))
+                    dirty = 1;
+            }
+            else if (PAD_justPressed(BTN_RIGHT)) {
+                if (list_page_down(&podcast_manage_selected, &podcast_manage_scroll, PODCAST_MANAGE_COUNT, items_per_page))
+                    dirty = 1;
             }
             else if (PAD_justPressed(BTN_A)) {
                 switch (podcast_manage_selected) {
@@ -420,6 +443,7 @@ ModuleExitReason PodcastModule_run(SDL_Surface* screen) {
         else if (state == PODCAST_INTERNAL_TOP_SHOWS) {
             Podcast_update();
             const PodcastChartsStatus* chart_status = Podcast_getChartsStatus();
+            int items_per_page = calc_list_layout(screen).list_h / (SCALE1(PILL_SIZE) * 3 / 2);
 
             if (chart_status->loading || chart_status->completed) dirty = 1;
             if (podcast_toast_message[0] && (SDL_GetTicks() - podcast_toast_time < TOAST_DURATION)) dirty = 1;
@@ -498,6 +522,22 @@ ModuleExitReason PodcastModule_run(SDL_Surface* screen) {
                 state = PODCAST_INTERNAL_MANAGE;
                 dirty = 1;
             }
+            else if (!chart_status->loading) {
+                int count = 0;
+                Podcast_getTopShows(&count);
+                if (PAD_justPressed(BTN_LEFT) && count > 0) {
+                    if (list_page_up(&podcast_top_shows_selected, &podcast_top_shows_scroll, count, items_per_page)) {
+                        Podcast_clearTitleScroll();
+                        dirty = 1;
+                    }
+                }
+                else if (PAD_justPressed(BTN_RIGHT) && count > 0) {
+                    if (list_page_down(&podcast_top_shows_selected, &podcast_top_shows_scroll, count, items_per_page)) {
+                        Podcast_clearTitleScroll();
+                        dirty = 1;
+                    }
+                }
+            }
         }
         // =========================================
         // SEARCH RESULTS STATE
@@ -505,6 +545,7 @@ ModuleExitReason PodcastModule_run(SDL_Surface* screen) {
         else if (state == PODCAST_INTERNAL_SEARCH_RESULTS) {
             Podcast_update();
             const PodcastSearchStatus* search_status = Podcast_getSearchStatus();
+            int items_per_page = calc_list_layout(screen).list_h / (SCALE1(PILL_SIZE) * 3 / 2);
 
             if (search_status->searching || search_status->completed) dirty = 1;
             if (podcast_toast_message[0] && (SDL_GetTicks() - podcast_toast_time < TOAST_DURATION)) dirty = 1;
@@ -575,6 +616,22 @@ ModuleExitReason PodcastModule_run(SDL_Surface* screen) {
                 state = PODCAST_INTERNAL_MANAGE;
                 dirty = 1;
             }
+            else if (!search_status->searching) {
+                int count = 0;
+                Podcast_getSearchResults(&count);
+                if (PAD_justPressed(BTN_LEFT) && count > 0) {
+                    if (list_page_up(&podcast_search_selected, &podcast_search_scroll, count, items_per_page)) {
+                        Podcast_clearTitleScroll();
+                        dirty = 1;
+                    }
+                }
+                else if (PAD_justPressed(BTN_RIGHT) && count > 0) {
+                    if (list_page_down(&podcast_search_selected, &podcast_search_scroll, count, items_per_page)) {
+                        Podcast_clearTitleScroll();
+                        dirty = 1;
+                    }
+                }
+            }
         }
         // =========================================
         // EPISODES STATE
@@ -582,6 +639,7 @@ ModuleExitReason PodcastModule_run(SDL_Surface* screen) {
         else if (state == PODCAST_INTERNAL_EPISODES) {
             PodcastFeed* feed = Podcast_getSubscription(podcast_current_feed_index);
             int count = feed ? feed->episode_count : 0;
+            int items_per_page = calc_list_layout(screen).list_h / (SCALE1(PILL_SIZE) * 3 / 2);
 
             // Check if refresh just completed
             if (Podcast_checkRefreshCompleted()) {
@@ -623,6 +681,18 @@ ModuleExitReason PodcastModule_run(SDL_Surface* screen) {
                 podcast_episodes_selected = (podcast_episodes_selected < count - 1) ? podcast_episodes_selected + 1 : 0;
                 Podcast_clearTitleScroll();
                 dirty = 1;
+            }
+            else if (PAD_justPressed(BTN_LEFT) && count > 0) {
+                if (list_page_up(&podcast_episodes_selected, &podcast_episodes_scroll, count, items_per_page)) {
+                    Podcast_clearTitleScroll();
+                    dirty = 1;
+                }
+            }
+            else if (PAD_justPressed(BTN_RIGHT) && count > 0) {
+                if (list_page_down(&podcast_episodes_selected, &podcast_episodes_scroll, count, items_per_page)) {
+                    Podcast_clearTitleScroll();
+                    dirty = 1;
+                }
             }
             else if (PAD_justPressed(BTN_A) && count > 0 && feed) {
                 podcast_current_episode_index = podcast_episodes_selected;
@@ -727,6 +797,7 @@ ModuleExitReason PodcastModule_run(SDL_Surface* screen) {
             static int prev_queue_count = -1;
             int queue_count = 0;
             Podcast_getDownloadQueue(&queue_count);
+            int items_per_page = calc_list_layout(screen).list_h / (SCALE1(PILL_SIZE) * 3 / 2);
 
             // Detect items removed by background download thread
             if (prev_queue_count >= 0 && queue_count < prev_queue_count) {
@@ -759,6 +830,18 @@ ModuleExitReason PodcastModule_run(SDL_Surface* screen) {
                 podcast_queue_selected = (podcast_queue_selected < queue_count - 1) ? podcast_queue_selected + 1 : 0;
                 Podcast_clearTitleScroll();
                 dirty = 1;
+            }
+            else if (PAD_justPressed(BTN_LEFT) && queue_count > 0) {
+                if (list_page_up(&podcast_queue_selected, &podcast_queue_scroll, queue_count, items_per_page)) {
+                    Podcast_clearTitleScroll();
+                    dirty = 1;
+                }
+            }
+            else if (PAD_justPressed(BTN_RIGHT) && queue_count > 0) {
+                if (list_page_down(&podcast_queue_selected, &podcast_queue_scroll, queue_count, items_per_page)) {
+                    Podcast_clearTitleScroll();
+                    dirty = 1;
+                }
             }
             else if (PAD_justPressed(BTN_X) && queue_count > 0) {
                 // Cancel/remove selected item

--- a/src/module_radio.c
+++ b/src/module_radio.c
@@ -206,6 +206,7 @@ ModuleExitReason RadioModule_run(SDL_Surface* screen) {
         if (state == RADIO_INTERNAL_LIST) {
             RadioStation* stations;
             int station_count = Radio_getStations(&stations);
+            int items_per_page = calc_list_layout(screen).items_per_page;
 
             if (PAD_justRepeated(BTN_UP) && station_count > 0) {
                 radio_selected = (radio_selected > 0) ? radio_selected - 1 : station_count - 1;
@@ -213,6 +214,14 @@ ModuleExitReason RadioModule_run(SDL_Surface* screen) {
             }
             else if (PAD_justRepeated(BTN_DOWN) && station_count > 0) {
                 radio_selected = (radio_selected < station_count - 1) ? radio_selected + 1 : 0;
+                dirty = 1;
+            }
+            else if (PAD_justPressed(BTN_LEFT) && station_count > 0) {
+                list_page_up(&radio_selected, &radio_scroll, station_count, items_per_page);
+                dirty = 1;
+            }
+            else if (PAD_justPressed(BTN_RIGHT) && station_count > 0) {
+                list_page_down(&radio_selected, &radio_scroll, station_count, items_per_page);
                 dirty = 1;
             }
             else if (PAD_justPressed(BTN_A) && station_count > 0) {
@@ -381,6 +390,7 @@ ModuleExitReason RadioModule_run(SDL_Surface* screen) {
         // =========================================
         else if (state == RADIO_INTERNAL_ADD_COUNTRY) {
             int country_count = Radio_getCuratedCountryCount();
+            int items_per_page = calc_list_layout(screen).items_per_page;
 
             if (PAD_justRepeated(BTN_UP) && country_count > 0) {
                 add_country_selected = (add_country_selected > 0) ? add_country_selected - 1 : country_count - 1;
@@ -388,6 +398,14 @@ ModuleExitReason RadioModule_run(SDL_Surface* screen) {
             }
             else if (PAD_justRepeated(BTN_DOWN) && country_count > 0) {
                 add_country_selected = (add_country_selected < country_count - 1) ? add_country_selected + 1 : 0;
+                dirty = 1;
+            }
+            else if (PAD_justPressed(BTN_LEFT) && country_count > 0) {
+                list_page_up(&add_country_selected, &add_country_scroll, country_count, items_per_page);
+                dirty = 1;
+            }
+            else if (PAD_justPressed(BTN_RIGHT) && country_count > 0) {
+                list_page_down(&add_country_selected, &add_country_scroll, country_count, items_per_page);
                 dirty = 1;
             }
             else if (PAD_justPressed(BTN_A) && country_count > 0) {
@@ -416,6 +434,7 @@ ModuleExitReason RadioModule_run(SDL_Surface* screen) {
         else if (state == RADIO_INTERNAL_ADD_STATIONS) {
             int station_count = 0;
             const CuratedStation* stations = Radio_getCuratedStations(add_selected_country_code, &station_count);
+            int items_per_page = calc_list_layout(screen).items_per_page;
 
             if (PAD_justRepeated(BTN_UP) && sorted_station_count > 0) {
                 add_station_selected = (add_station_selected > 0) ? add_station_selected - 1 : sorted_station_count - 1;
@@ -423,6 +442,14 @@ ModuleExitReason RadioModule_run(SDL_Surface* screen) {
             }
             else if (PAD_justRepeated(BTN_DOWN) && sorted_station_count > 0) {
                 add_station_selected = (add_station_selected < sorted_station_count - 1) ? add_station_selected + 1 : 0;
+                dirty = 1;
+            }
+            else if (PAD_justPressed(BTN_LEFT) && sorted_station_count > 0) {
+                list_page_up(&add_station_selected, &add_station_scroll, sorted_station_count, items_per_page);
+                dirty = 1;
+            }
+            else if (PAD_justPressed(BTN_RIGHT) && sorted_station_count > 0) {
+                list_page_down(&add_station_selected, &add_station_scroll, sorted_station_count, items_per_page);
                 dirty = 1;
             }
             else if (PAD_justPressed(BTN_A) && sorted_station_count > 0) {

--- a/src/module_settings.c
+++ b/src/module_settings.c
@@ -7,6 +7,7 @@
 #include "selfupdate.h"
 #include "downloader.h"
 #include "ui_settings.h"
+#include "ui_utils.h"
 #include "ui_system.h"
 #include "wifi.h"
 #include "album_art.h"
@@ -37,6 +38,7 @@ typedef enum {
 ModuleExitReason SettingsModule_run(SDL_Surface* screen) {
     SettingsState state = SETTINGS_STATE_MENU;
     int menu_selected = 0;
+    int menu_scroll = 0;
     int dirty = 1;
     int show_setting = 0;
 
@@ -72,7 +74,7 @@ ModuleExitReason SettingsModule_run(SDL_Surface* screen) {
                         dirty = 1;
                     }
                 }
-                // Left/Right for cyclable settings
+                // Left/Right for cyclable settings; page navigation for others
                 else if (PAD_justPressed(BTN_LEFT)) {
                     if (menu_selected == SETTINGS_ITEM_SCREEN_OFF) {
                         Settings_cycleScreenOffPrev();
@@ -82,6 +84,10 @@ ModuleExitReason SettingsModule_run(SDL_Surface* screen) {
                         dirty = 1;
                     } else if (menu_selected == SETTINGS_ITEM_SOFT_LIMITER) {
                         Settings_cycleSoftLimiterPrev();
+                        dirty = 1;
+                    } else {
+                        int items_per_page = calc_list_layout(screen).items_per_page;
+                        list_page_up(&menu_selected, &menu_scroll, SETTINGS_ITEM_COUNT, items_per_page);
                         dirty = 1;
                     }
                 }
@@ -94,6 +100,10 @@ ModuleExitReason SettingsModule_run(SDL_Surface* screen) {
                         dirty = 1;
                     } else if (menu_selected == SETTINGS_ITEM_SOFT_LIMITER) {
                         Settings_cycleSoftLimiterNext();
+                        dirty = 1;
+                    } else {
+                        int items_per_page = calc_list_layout(screen).items_per_page;
+                        list_page_down(&menu_selected, &menu_scroll, SETTINGS_ITEM_COUNT, items_per_page);
                         dirty = 1;
                     }
                 }

--- a/src/ui_main.c
+++ b/src/ui_main.c
@@ -162,6 +162,7 @@ typedef struct {
 // Main menu controls (A/B shown in footer)
 static const ControlHelp main_menu_controls[] = {
     {"Up/Down", "Navigate"},
+    {"Left/Right", "Navigate"},
     {"X", "Clear History/Playback"},
     {"Start (hold)", "Exit App"},
     {NULL, NULL}
@@ -170,6 +171,7 @@ static const ControlHelp main_menu_controls[] = {
 // File browser controls (A/B shown in footer)
 static const ControlHelp browser_controls[] = {
     {"Up/Down", "Navigate"},
+    {"Left/Right", "Navigate"},
     {"Y", "Add to Playlist"},
     {"X", "Delete File"},
     {"Start (hold)", "Exit App"},
@@ -194,6 +196,7 @@ static const ControlHelp player_controls[] = {
 // Radio list controls (A/B shown in footer)
 static const ControlHelp radio_list_controls[] = {
     {"Up/Down", "Navigate"},
+    {"Left/Right", "Navigate"},
     {"Y", "Manage Stations"},
     {"X", "Delete Station"},
     {"Start (hold)", "Exit App"},
@@ -213,6 +216,7 @@ static const ControlHelp radio_playing_controls[] = {
 // Radio manage stations controls - country list (A/B shown in footer)
 static const ControlHelp radio_manage_controls[] = {
     {"Up/Down", "Navigate"},
+    {"Left/Right", "Navigate"},
     {"Y", "Manual Setup Help"},
     {"Start (hold)", "Exit App"},
     {NULL, NULL}
@@ -221,6 +225,7 @@ static const ControlHelp radio_manage_controls[] = {
 // Radio browse stations controls - station list (A/B shown in footer)
 static const ControlHelp radio_browse_controls[] = {
     {"Up/Down", "Navigate"},
+    {"Left/Right", "Navigate"},
     {"A", "Add/Remove Station"},
     {"Y", "Manual Setup Help"},
     {"Start (hold)", "Exit App"},
@@ -230,6 +235,7 @@ static const ControlHelp radio_browse_controls[] = {
 // Podcast menu controls (shows subscribed podcasts)
 static const ControlHelp podcast_menu_controls[] = {
     {"Up/Down", "Navigate"},
+    {"Left/Right", "Navigate"},
     {"X", "Unsubscribe"},
     {"Y", "Manage Podcasts"},
     {"Start (hold)", "Exit App"},
@@ -239,6 +245,7 @@ static const ControlHelp podcast_menu_controls[] = {
 // Podcast manage menu controls
 static const ControlHelp podcast_manage_controls[] = {
     {"Up/Down", "Navigate"},
+    {"Left/Right", "Navigate"},
     {"Start (hold)", "Exit App"},
     {NULL, NULL}
 };
@@ -246,6 +253,7 @@ static const ControlHelp podcast_manage_controls[] = {
 // Podcast subscriptions list controls
 static const ControlHelp podcast_subscriptions_controls[] = {
     {"Up/Down", "Navigate"},
+    {"Left/Right", "Navigate"},
     {"X", "Unsubscribe"},
     {"Start (hold)", "Exit App"},
     {NULL, NULL}
@@ -254,6 +262,7 @@ static const ControlHelp podcast_subscriptions_controls[] = {
 // Podcast top shows controls
 static const ControlHelp podcast_top_shows_controls[] = {
     {"Up/Down", "Navigate"},
+    {"Left/Right", "Navigate"},
     {"A", "Subscribe/Unsubscribe"},
     {"X", "Refresh List"},
     {"Start (hold)", "Exit App"},
@@ -263,6 +272,7 @@ static const ControlHelp podcast_top_shows_controls[] = {
 // Podcast search results controls
 static const ControlHelp podcast_search_controls[] = {
     {"Up/Down", "Navigate"},
+    {"Left/Right", "Navigate"},
     {"A", "Subscribe/Unsubscribe"},
     {"Start (hold)", "Exit App"},
     {NULL, NULL}
@@ -271,6 +281,7 @@ static const ControlHelp podcast_search_controls[] = {
 // Podcast episodes list controls
 static const ControlHelp podcast_episodes_controls[] = {
     {"Up/Down", "Navigate"},
+    {"Left/Right", "Navigate"},
     {"Y", "Refresh Episodes"},
     {"X", "Mark Played/Unplayed"},
     {"Start (hold)", "Exit App"},
@@ -290,6 +301,7 @@ static const ControlHelp podcast_playing_controls[] = {
 // YouTube menu controls (A/B shown in footer)
 static const ControlHelp youtube_menu_controls[] = {
     {"Up/Down", "Navigate"},
+    {"Left/Right", "Navigate"},
     {"Start (hold)", "Exit App"},
     {NULL, NULL}
 };
@@ -297,6 +309,7 @@ static const ControlHelp youtube_menu_controls[] = {
 // YouTube results controls (A/B shown in footer)
 static const ControlHelp youtube_results_controls[] = {
     {"Up/Down", "Navigate"},
+    {"Left/Right", "Navigate"},
     {"B", "Back"},
     {"Start (hold)", "Exit App"},
     {NULL, NULL}
@@ -305,6 +318,7 @@ static const ControlHelp youtube_results_controls[] = {
 // YouTube queue controls (A/B/X shown in footer)
 static const ControlHelp youtube_queue_controls[] = {
     {"Up/Down", "Navigate"},
+    {"Left/Right", "Navigate"},
     {"Start (hold)", "Exit App"},
     {NULL, NULL}
 };
@@ -312,6 +326,7 @@ static const ControlHelp youtube_queue_controls[] = {
 // Playlist list controls (A/B shown in footer)
 static const ControlHelp playlist_list_controls[] = {
     {"Up/Down", "Navigate"},
+    {"Left/Right", "Navigate"},
     {"X", "Delete Playlist"},
     {"Start (hold)", "Exit App"},
     {NULL, NULL}
@@ -320,6 +335,7 @@ static const ControlHelp playlist_list_controls[] = {
 // Playlist detail controls (A/B shown in footer)
 static const ControlHelp playlist_detail_controls[] = {
     {"Up/Down", "Navigate"},
+    {"Left/Right", "Navigate"},
     {"X", "Remove Track"},
     {"Start (hold)", "Exit App"},
     {NULL, NULL}
@@ -334,7 +350,7 @@ static const ControlHelp about_controls[] = {
 // Settings menu controls
 static const ControlHelp settings_controls[] = {
     {"Up/Down", "Navigate"},
-    {"Left/Right", "Change Value"},
+    {"Left/Right", "Change Value/Navigate"},
     {"Start (hold)", "Exit App"},
     {NULL, NULL}
 };

--- a/src/ui_utils.c
+++ b/src/ui_utils.c
@@ -294,6 +294,78 @@ void adjust_list_scroll(int selected, int* scroll, int items_per_page) {
     }
 }
 
+bool list_page_up(int *selected, int *scroll, int total_count, int items_per_page) {
+    if (items_per_page < 1) {
+        items_per_page = 1;
+    }
+
+    int old_scroll   = *scroll;
+    int old_selected = *selected;
+    int relative_pos = *selected - *scroll;
+    if (relative_pos < 0) {
+        relative_pos = 0;
+    } else if (relative_pos > items_per_page) {
+        relative_pos = items_per_page;
+    }
+
+    *scroll -= items_per_page;
+    if (*scroll < 0) {
+        *scroll = 0;
+    }
+
+    // keep position of selected item on the screen, snap to the first item if needed
+    if (*scroll == old_scroll) {
+        *selected = 0;
+    } else {
+        *selected = *scroll + relative_pos;
+    }
+
+    if (*selected < 0) {
+        *selected = 0;
+    } else if (*selected >= total_count) {
+        *selected = total_count - 1;
+    }
+
+    return (*scroll != old_scroll || *selected != old_selected);
+}
+
+bool list_page_down(int *selected, int *scroll, int total_count, int items_per_page) {
+    if (items_per_page < 1) {
+        items_per_page = 1;
+    }
+
+    int old_scroll   = *scroll;
+    int old_selected = *selected;
+    int max_scroll   = (total_count > items_per_page) ? total_count - items_per_page : 0;
+
+    int relative_pos = *selected - *scroll;
+    if (relative_pos < 0) {
+        relative_pos = 0;
+    } else if (relative_pos > items_per_page) {
+        relative_pos = items_per_page;
+    }
+
+    *scroll += items_per_page;
+    if (*scroll > max_scroll) {
+        *scroll = max_scroll;
+    }
+
+    // keep position of selected item on the screen, snap to the last item if needed
+    if (*scroll == old_scroll) {
+        *selected = total_count - 1;
+    } else {
+        *selected = *scroll + relative_pos;
+    }
+
+    if (*selected >= total_count) {
+        *selected = total_count - 1;
+    } else if (*selected < 0) {
+        *selected = 0;
+    }
+
+    return (*scroll != old_scroll || *selected != old_selected);
+}
+
 // Render scroll up/down indicators for lists
 void render_scroll_indicators(SDL_Surface* screen, int scroll, int items_per_page, int total_count) {
     if (total_count <= items_per_page) return;

--- a/src/ui_utils.h
+++ b/src/ui_utils.h
@@ -66,6 +66,16 @@ void render_screen_header(SDL_Surface* screen, const char* title, int show_setti
 // Adjust scroll offset to keep selected item visible
 void adjust_list_scroll(int selected, int* scroll, int items_per_page);
 
+// Page toward the beginning of the list (lower indices), adusting scroll position and selection accordingly.
+// Returns true if selection or scroll changed.
+// Note: non-positive items_per_page is treated as 1.
+bool list_page_up(int *selected, int *scroll, int total_count, int items_per_page);
+
+// Page toward the end of the list (higher indices), adusting scroll position and selection accordingly.
+// Returns true if selection or scroll changed
+// Note: non-positive items_per_page is treated as 1.
+bool list_page_down(int *selected, int *scroll, int total_count, int items_per_page);
+
 // Render scroll up/down indicators for lists
 void render_scroll_indicators(SDL_Surface* screen, int scroll, int items_per_page, int total_count);
 


### PR DESCRIPTION
## Summary

There is a usability issue: in the lists, only UP/DOWN buttons perform navigation, which is not optimal to use on longer lists, especially in the file browser, see issue #20 .

This change adds LEFT/RIGHT button handling in a way consistent with NextUI interface:

- Adds `list_page_up` / `list_page_down` helpers (`ui_utils.c/h`) that implement list page navigation logic:
  - Preserve the cursor's relative position within the visible window
  - The window scrolls by one page, the cursor stays at the same row
  - When the window can't move further (already at first/last page), the cursor snaps to the first/last item in the list
- Wires LEFT/RIGHT into every scrollable list in the app
  - File browser
  - Playlists
  - Radio (station list + browse country/station)
  - Podcasts (menu, manage, top shows, search results, episodes, download queue)
  - Downloader (search results, download queue)
  - Settings (cycles the value for cyclable items, pages for non-cyclable)
  - All simple menus (main menu, library, downloader menu)
- In-app controls help dialogs updated to include
  - `Left/Right │ Change Value/Navigate` for settings (the only place that needs left/right buttons in a list)
  - `Left/Right │ Navigate` for other list screens

## Test plan

- [x] File browser: LEFT/RIGHT pages through tracks; cursor stays at same row position within page
- [x] Playlists list and detail: same paging behaviour
- [x] Radio station list, add-country list, add-stations list: paging works
- [x] Podcast menu, manage, top shows, search results, episodes, download queue: paging works; title scroll clears on page
- [x] Downloader search results and download queue: paging works
- [x] Settings: LEFT/RIGHT cycles value on cyclable items (screen-off, bass filter, soft limiter); pages on all other items
- [x] Simple menus (main menu, library, downloader menu): LEFT goes to first item, RIGHT goes to last
- [x] Controls help dialog (START) shows "Navigate" for LEFT/RIGHT on all screens
- [x] At last page: RIGHT snaps cursor to last item; at first page: LEFT snaps to first item